### PR TITLE
Fix code to use new name for zyp_inst functio

### DIFF
--- a/scripts/libs/opensuse.shlib
+++ b/scripts/libs/opensuse.shlib
@@ -20,6 +20,8 @@ function zypp_inst {
   fi
 }
 
+alias zyp_inst=zypp_inst
+
 function zypp_install_pkgs {
   local install_root=${1}
 
@@ -28,6 +30,6 @@ function zypp_install_pkgs {
 
   for PKG in $(jq -r '.opensuse.pkgs | .[]' ${install_root}/scripts/data/pkgs.json); do
     say "${FG_L_GREEN}INSTALLING $PKG${NORMAL}"
-    zyp_inst $PKG
+    zypp_inst $PKG
   done
 }


### PR DESCRIPTION
- Add alias to old name for compatibility

In support of #98 

Signed-off-by: Gary Greene <greeneg@tolharadys.net>