### PR TITLE
Align with Perl 7, fix bug, bump version

### DIFF
--- a/bin/buyo.psgi
+++ b/bin/buyo.psgi
@@ -17,9 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package main v1.2.19 {
-    use strict;
-    use warnings;
+package main v1.2.21 {
+    use strictures;
     use English qw(-no_match_vars);
     use utf8;
 
@@ -56,6 +55,8 @@ package main v1.2.19 {
     my $DEBUG = true;
 
     my sub main (@args) {
+        my $sub = (caller(0))[3];
+        err_log("== DEBUGGING ==: Sub: " . $sub) if $DEBUG;
         say {*STDERR} '>> Starting the Buyo application server version '. $Buyo::Constants::VERSION;
         say {*STDERR} '>> '. $Buyo::Constants::license;
         say {*STDERR} '-------------------------------------------------------------';

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -16,9 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package Buyo v1.2.19 {
-    use strict;
-    use warnings FATAL => 'all';
+package Buyo v1.2.21 {
+    use strictures;
     use English qw(-no_match_vars);
     use utf8;
 
@@ -475,7 +474,7 @@ package Buyo v1.2.19 {
                             my $do_launch = validate_page_launch_date($bindings{$path}->{$verb}->{'launchDate'}, time);
                             my $expire_page = expire_page($bindings{$path}->{$verb}->{'expireDate'}, time);
 
-                            my $articles = build_article_struct_list($config);
+                            my $articles = build_article_struct_list();
                             err_log("== DEBUGGING ==: Triggerng '" . uc($verb) . "' action for path '$path'") if $config->{'debug'};
                             err_log("== DEBUGGING ==: Generating page for '$class'") if $config->{'debug'};
                             return template $template, {

--- a/lib/Buyo/Constants.pm
+++ b/lib/Buyo/Constants.pm
@@ -17,9 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package Buyo::Constants v1.2.19 {
-    use strict;
-    use warnings;
+package Buyo::Constants v1.2.21 {
+    use strictures;
     use English qw(-no_match_vars);
     use utf8;
 

--- a/lib/Buyo/Utils.pm
+++ b/lib/Buyo/Utils.pm
@@ -17,9 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package Buyo::Utils v1.2.19 {
-    use strict;
-    use warnings;
+package Buyo::Utils v1.2.21 {
+    use strictures;
     use English qw(-no_match_vars);
     use utf8;
 


### PR DESCRIPTION
- Perl 7 will automatically use the strictures pragma, which turns on the following settings:
```perl
use strict;
use warnings FATAL => 'all';
use warnings NONFATAL => qw(
  exec
  recursion
  internal
  malloc
  newline
  experimental
  deprecated
  portable
);
no warnings 'once';
```
- Fix bug in News page, causing an ISE
- Bump to v1.2.21

Signed-off-by: Gary Greene <greeneg@tolharadys.net>