### PR TITLE
Correct various places that list the wrong year

### DIFF
--- a/bindings.json
+++ b/bindings.json
@@ -2,8 +2,8 @@
     "binding_version": "3.0",
     "info": {
         "title": "JAFAX",
-        "version": "2019.0.99",
-        "copyright": "JAFAX Inc. &copy;2019",
+        "version": "2020.11.1",
+        "copyright": "JAFAX Inc. &copy;2020",
         "license": "Apache Public License, v2.0"
     },
     "menus": {
@@ -202,7 +202,7 @@
         "/": {
             "get": {
                 "active": "true",
-                "summary": "2020",
+                "summary": "2021",
                 "template": "index",
                 "launchDate": 1438401600,
                 "expireDate": -1,

--- a/views/layouts/_footer.tt
+++ b/views/layouts/_footer.tt
@@ -34,7 +34,7 @@
                         </div>
                     </div>
                 </div>
-                <p class="copyright">JAFAX, Inc., ©2019-2020<br />
+                <p class="copyright">JAFAX, Inc., &copy;2019-2020<br />
                 The software running this site is open source. Collaborate with us on <a href="https://github.com/JAFAX/jafax.org">GitHub</a>!</p>
             </footer>
         </div>


### PR DESCRIPTION
This PR changes the title of the event's page to refer to 2021. Additionally,
it corrects the date of the site's copyright, and uses the character code for
the copyright character, instead of relying on unicode support.

Closes #186 

Signed-off-by: Gary Greene <greeneg@tolharadys.net>