### PR TITLE
Add validation to reCAPTCHA

### DIFF
--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -353,7 +353,7 @@ package Buyo {
         my $encoded_response    = $uri_enc->encode($response_data);
         err_log("== DEBUGGING ==: response: $response_data") if $config->{'debug'};
         err_log("== DEBUGGING ==: encoded response: $encoded_response") if $config->{'debug'};
-        my $query   = '?secret=' . $service_key . '&response=' . $response;
+        my $query   = '?secret=' . $secret_key . '&response=' . $response;
         err_log("== DEBUGGING ==: query string: $query") if $config->{'debug'};
         my $req     = HTTP::Request->new(POST => "${url}${query}");
         my $result  = $ua->request($req);

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -124,6 +124,7 @@ package Buyo {
         $configuration{'etcd_user'}       = $cfg->val('etcd', 'user');
         $configuration{'etcd_password'}   = $cfg->val('etcd', 'pass');
         $configuration{'site_key'}        = $cfg->val('reCAPTCHA', 'site_key');
+        $configuration{'service_key'}     = $cfg->val('reCAPTCHA', 'service_key');
 
         err_log("== DEBUGGING ==: Config DUMP: ". Dumper(%configuration));
 

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package Buyo v1.2.22 {
+package Buyo {
     use strictures;
     use English qw(-no_match_vars);
     use utf8;
@@ -27,7 +27,9 @@ package Buyo v1.2.22 {
     use Dancer2;
     use JSON qw();
     use Data::Dumper;
+    use LWP::UserAgent;
     use MIME::Lite;
+    use URI::Encode;
     use Try::Tiny qw(try catch);
     use Throw qw(throw classify);
 
@@ -43,6 +45,8 @@ package Buyo v1.2.22 {
 
     use Buyo::Constants;
     use Buyo::Utils qw(err_log);
+
+    my $VERSION = $Buyo::Constants::VERSION;
 
     # this global is to avoid copying it everywhere
     our $config;
@@ -329,6 +333,32 @@ package Buyo v1.2.22 {
         return undef;
     }
 
+    my sub validate_recaptcha ($response_data) {
+        my $sub = (caller(0))[3];
+        err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
+
+        # build an LWP::UserAgent object
+        my $ua = LWP::UserAgent->new();
+        $ua->agent("Buyo Content Manager/$VERSION");
+
+        my $secret_key = $config->{'service_key'};
+        # create our post request to Google
+        my $url     = 'https://www.google.com/recaptcha/api/siteverify';
+        my $uri_enc = URI::Encode->new(encode_reserved => 0);
+        my $encoded_service_key = $uri_enc->encode($secret_key);
+        my $encoded_response    = $uri_enc->encode($response_data);
+        my $query   = '?secret=' . $encoded_service_key . '&response=' . $encoded_response;
+        my $req     = HTTP::Request->new(POST => "${url}${query}");
+        my $result  = $ua->request($req);
+        my $js_res  = decode_json($result->content);
+
+        if ($js_res->success eq 'true') {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     my sub send_email ($post_values) {
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -337,16 +367,24 @@ package Buyo v1.2.22 {
         my $email_address = get_department_email_from_id($config->{'appdir'}, $post_values->{'to_list'});
         my $email_subject = $post_values->{'email_subject'};
         my $email_body    = "Message sent from: $post_values->{'email_address'}\n\nMessage:\n$post_values->{'email_body'}\n";
-        # construct email
-        my $msg = MIME::Lite->new(
-            From     => 'noreply@jafax.org',
-            To       => $email_address,
-            Subject  => $email_subject,
-            Type     => 'TEXT',
-            Encoding => 'quoted-printable',
-            Data     => $email_body,
-        );
-        $msg->send('sendmail', '/usr/sbin/sendmail -t -oi -oem');
+
+        # validate that the user was real using the reCAPTCHA post data
+        my $response      = validate_recaptcha($post_values->{'g-recaptcha-response'});
+
+        if ($response eq true) {
+            # construct email
+            my $msg = MIME::Lite->new(
+                From     => 'noreply@jafax.org',
+                To       => $email_address,
+                Subject  => $email_subject,
+                Type     => 'TEXT',
+                Encoding => 'quoted-printable',
+                Data     => $email_body,
+            );
+            $msg->send('sendmail', '/usr/sbin/sendmail -t -oi -oem');
+        } else {
+            err_log("== WARNING ==: Got a bot posting stuff: email address ". $post_values->{'email_address'});
+        }
     }
 
     my sub get_last_three_article_structs ($articles) {
@@ -774,6 +812,7 @@ package Buyo v1.2.22 {
             'article_mech'  => $configuration{'article_mech'},
             'debug'         => $configuration{'debug'},
             'site_key'      => $configuration{'site_key'},
+            'service_key'   => $configuration{'service_key'},
             'configuration' => \%configuration
         };
 

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -361,6 +361,7 @@ package Buyo {
         my $result  = $ua->request($req);
         err_log("== DEBUGGING ==: response: ". Dumper($result)) if $config->{'debug'};
         my $js_res  = decode_json($result->content);
+        err_log("== DEBUGGING ==: decoded response: ". Dumper($js_res)) if $config->{'debug'};
 
         if ($js_res->success eq 'true') {
             return true;

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -353,7 +353,7 @@ package Buyo {
         my $encoded_response    = $uri_enc->encode($response_data);
         err_log("== DEBUGGING ==: response: $response_data") if $config->{'debug'};
         err_log("== DEBUGGING ==: encoded response: $encoded_response") if $config->{'debug'};
-        my $query   = '?secret=' . $secret_key . '&response=' . $response;
+        my $query   = '?secret=' . $secret_key . '&response=' . $response_data;
         err_log("== DEBUGGING ==: query string: $query") if $config->{'debug'};
         my $req     = HTTP::Request->new(POST => "${url}${query}");
         my $result  = $ua->request($req);

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -333,6 +333,7 @@ package Buyo v1.2.22 {
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
+        err_log("== DEBUGGING ==: DUMP POST VALUES: ". Dumper($post_values)) if $config->{'debug'};
         my $email_address = get_department_email_from_id($config->{'appdir'}, $post_values->{'to_list'});
         my $email_subject = $post_values->{'email_subject'};
         my $email_body    = "Message sent from: $post_values->{'email_address'}\n\nMessage:\n$post_values->{'email_body'}\n";

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -340,7 +340,7 @@ package Buyo {
 
         # build an LWP::UserAgent object
         my $ua = LWP::UserAgent->new();
-        $ua->agent("Buyo Content Manager/$VERSION");
+        $ua->agent("BuyoContentManager/reCAPTCHA/$VERSION");
 
         my $secret_key = $config->{'service_key'};
         # create our post request to Google
@@ -356,6 +356,8 @@ package Buyo {
         my $query   = '?secret=' . $secret_key . '&response=' . $response_data;
         err_log("== DEBUGGING ==: query string: $query") if $config->{'debug'};
         my $req     = HTTP::Request->new(POST => "${url}${query}");
+        $req->content_type('application/x-www-form-urlencoded');
+        $req->header('Content-Length' => 0);
         my $result  = $ua->request($req);
         err_log("== DEBUGGING ==: response: ". Dumper($result)) if $config->{'debug'};
         my $js_res  = decode_json($result->content);

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -349,10 +349,15 @@ package Buyo {
         err_log("== DEBUGGING ==: config dump: ". Dumper($config)) if $config->{'debug'};
         err_log("== DEBUGGING ==: secret key: $secret_key") if $config->{'debug'};
         my $encoded_service_key = $uri_enc->encode($secret_key);
+        err_log("== DEBUGGING ==: encoded service key: $encoded_service_key") if $config->{'debug'};
         my $encoded_response    = $uri_enc->encode($response_data);
+        err_log("== DEBUGGING ==: response: $response_data") if $config->{'debug'};
+        err_log("== DEBUGGING ==: encoded response: $encoded_response") if $config->{'debug'};
         my $query   = '?secret=' . $encoded_service_key . '&response=' . $encoded_response;
+        err_log("== DEBUGGING ==: query string: $query") if $config->{'debug'};
         my $req     = HTTP::Request->new(POST => "${url}${query}");
         my $result  = $ua->request($req);
+        err_log("== DEBUGGING ==: response: ". Dumper($result)) if $config->{'debug'};
         my $js_res  = decode_json($result->content);
 
         if ($js_res->success eq 'true') {

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -345,6 +345,7 @@ package Buyo {
         # create our post request to Google
         my $url     = 'https://www.google.com/recaptcha/api/siteverify';
         my $uri_enc = URI::Encode->new(encode_reserved => 0);
+        err_log("== DEBUGGING ==: secret key: $secret_key") if $config->{'debug'};
         my $encoded_service_key = $uri_enc->encode($secret_key);
         my $encoded_response    = $uri_enc->encode($response_data);
         my $query   = '?secret=' . $encoded_service_key . '&response=' . $encoded_response;

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -363,7 +363,7 @@ package Buyo {
         my $js_res  = decode_json($result->content);
         err_log("== DEBUGGING ==: decoded response: ". Dumper($js_res)) if $config->{'debug'};
 
-        if ($js_res->success eq 'true') {
+        if ($js_res->{'success'} eq 'true') {
             return true;
         } else {
             return false;

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -353,7 +353,7 @@ package Buyo {
         my $encoded_response    = $uri_enc->encode($response_data);
         err_log("== DEBUGGING ==: response: $response_data") if $config->{'debug'};
         err_log("== DEBUGGING ==: encoded response: $encoded_response") if $config->{'debug'};
-        my $query   = '?secret=' . $encoded_service_key . '&response=' . $encoded_response;
+        my $query   = '?secret=' . $service_key . '&response=' . $response;
         err_log("== DEBUGGING ==: query string: $query") if $config->{'debug'};
         my $req     = HTTP::Request->new(POST => "${url}${query}");
         my $result  = $ua->request($req);

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -345,6 +345,7 @@ package Buyo {
         # create our post request to Google
         my $url     = 'https://www.google.com/recaptcha/api/siteverify';
         my $uri_enc = URI::Encode->new(encode_reserved => 0);
+        err_log("== DEBUGGING ==: config dump: ". Dumper($config)) if $config->{'debug'};
         err_log("== DEBUGGING ==: secret key: $secret_key") if $config->{'debug'};
         my $encoded_service_key = $uri_enc->encode($secret_key);
         my $encoded_response    = $uri_enc->encode($response_data);

--- a/lib/Buyo/MkRole.pm
+++ b/lib/Buyo/MkRole.pm
@@ -19,9 +19,10 @@ package Buyo::MkRole {
     use FindBin;
     use lib "$FindBin::Bin/../lib";
 
-    use File::IO;
-    use Sys::Error;
+    use File::IO 0.0.1;
+    use Sys::Error 0.0.1;
 
+    use Buyo::Constants;
     use Buyo::Utils;
 
     my $debug  = undef;
@@ -30,6 +31,8 @@ package Buyo::MkRole {
     my $fio    = undef;
     my $err    = undef;
     my $utils  = undef;
+
+    my $VERSION = $Buyo::Constants::VERSION;
 
     sub new ($class, $flags) {
         my $self = {};

--- a/views/layouts/_head.tt
+++ b/views/layouts/_head.tt
@@ -21,7 +21,6 @@
 
             function enableBtn(){
                 document.getElementById("submitBtn").disabled = false;
-                gresponse = grecaptcha.getResponse()
             }
         </script>
         [% END %]

--- a/views/layouts/_head.tt
+++ b/views/layouts/_head.tt
@@ -17,8 +17,11 @@
         [% IF path == '/contact' %]
         <script src="https://www.google.com/recaptcha/api.js" async defer></script>
         <script>
+            var gresponse;
+
             function enableBtn(){
                 document.getElementById("submitBtn").disabled = false;
+                gresponse = grecaptcha.getResponse()
             }
         </script>
         [% END %]


### PR DESCRIPTION
This PR adds validation to the reCAPTCHA, and ensures without a valid reCAPTCHA response, bots cannot send emails through the POST action of the /mail endpoint