### PR TITLE
Open panel registration and announce it. Fix sorting

### DIFF
--- a/content/11.json
+++ b/content/11.json
@@ -1,0 +1,11 @@
+{
+  "article_schema_version": "1.0",
+  "id": 11,
+  "info": {
+    "author": "WebMaster",
+    "date": "2022-04-15",
+    "category": "announcement"
+  },
+  "title": "Panel Registration now Open!",
+  "content": "<p>Are you educated and enthusiastic about a specific topic of anim&eacute; or Japanese culture? Do you enjoy entertaining and interacting with other fans of that topic? Come share your knowledge and creativity with your fellow attendees by hosting a panel!</p><p>Our Panel Registration form is now <a href=\"/events/panels\">live</a>! Panel submissions end on May 17th at 11:59pm. You will find out about the status of your panel by May 25th.</p>"
+}

--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -46,7 +46,7 @@ package Buyo {
     use lib "$FindBin::Bin/../lib";
 
     use Buyo::Constants;
-    use Buyo::Utils qw(err_log);
+    use Buyo::Utils qw(err_log type_check);
 
     use File::IO;
 
@@ -59,6 +59,10 @@ package Buyo {
     my $fio = undef;
 
     my sub error_msg :ReturnType(Void) ($error_struct, $class) {
+        my $caller = caller;
+        type_check($caller, $error_struct, 'Hash');
+        type_check($caller, $class, 'Str');
+
         say STDERR "Error struct dump: ". Dumper($error_struct);
 
         my $error   = $error_struct->{'error'};
@@ -75,6 +79,9 @@ package Buyo {
     }
 
     my sub load_config :ReturnType(Hash) ($appdir) {
+        my $caller = caller;
+        type_check($caller, $appdir, 'Str');
+
         my $sub = (caller(0))[3];
 
         my $ini_file = "${appdir}/conf.d/config.ini";
@@ -138,6 +145,9 @@ package Buyo {
     }
 
     my sub get_json :ReturnType(Str) ($json_file) {
+        my $caller = caller;
+        type_check($caller, $json_file, 'Str');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -168,6 +178,10 @@ package Buyo {
     }
 
     my sub get_article_from_json :ReturnType(list => Str) ($article, $type) {
+        my $caller = caller;
+        type_check($caller, $article, 'Str');
+        type_check($caller, $type, 'Str');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -215,6 +229,10 @@ package Buyo {
     }
 
     my sub get_file_list :ReturnType(list => Str) ($directory, $extension) {
+        my $caller = caller;
+        type_check($caller, $directory, 'Str');
+        type_check($caller, $extension, 'Str');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -232,6 +250,9 @@ package Buyo {
     }
 
     my sub build_menus_struct :ReturnType(Void) ($json_path) {
+        my $caller = caller;
+        type_check($caller, $json_path, 'Str');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -264,7 +285,7 @@ package Buyo {
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
         my $appdir = $config->{'appdir'};
-        my @files = sort { $b cmp $a} get_file_list("${appdir}content", 'json');
+        my @files = sort { $b cmp $a } get_file_list("${appdir}content", 'json');
 
         my @articles;
         foreach my $file (@files) {
@@ -289,6 +310,9 @@ package Buyo {
     }
 
     my sub get_department_contacts :ReturnType(Hash) ($appdir) {
+        my $caller = caller;
+        type_check($caller, $appdir, 'Str');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -315,6 +339,10 @@ package Buyo {
     }
 
     my sub get_department_email_from_id :ReturnType(Str) ($appdir, $value) {
+        my $caller = caller;
+        type_check($caller, $appdir, 'Str');
+        type_check($caller, $value, 'Str');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
         err_log("== DEBUGGING ==: Input \$value: $value") if $config->{'debug'};
@@ -336,6 +364,9 @@ package Buyo {
     }
 
     my sub validate_recaptcha :ReturnType(Bool) ($response_data) {
+        my $caller = caller;
+        type_check($caller, $response_data, 'Str');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -372,6 +403,9 @@ package Buyo {
     }
 
     my sub send_email :ReturnType(Void) ($post_values) {
+        my $caller = caller;
+        type_check($caller, $post_values, 'HashRef');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -400,6 +434,9 @@ package Buyo {
     }
 
     my sub get_last_three_article_structs :ReturnType(ArrayRef[Hash]) ($articles) {
+        my $caller = caller;
+        type_check($caller, $articles, 'ArrayRef');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -428,6 +465,10 @@ package Buyo {
     }
 
     my sub validate_page_launch_date :ReturnType(Bool) ($launch_date, $curr_date) {
+        my $caller = caller;
+        type_check($caller, $launch_date, 'Int');
+        type_check($caller, $curr_date, 'Int');
+
         my $do_launch = false;
         if ($curr_date >= $launch_date) {
             $do_launch = true;
@@ -437,6 +478,10 @@ package Buyo {
     }
 
     my sub expire_page :ReturnType(Bool) ($expiry_date, $curr_date) {
+        my $caller = caller;
+        type_check($caller, $expiry_date, 'Int');
+        type_check($caller, $curr_date, 'Int');
+
         my $expire = false;
         if ($expiry_date != -1) {
             if ($curr_date > $expiry_date) {
@@ -448,8 +493,13 @@ package Buyo {
     }
 
     my sub register_dynamic_route :ReturnType(Str) ($verb, $bindings, $path) {
+        my $caller = caller;
+        type_check($caller, $verb, 'Str');
+        type_check($caller, $bindings, 'HashRef');
+        type_check($caller, $path, 'Str');
+
         # un-reference to make easier to work with
-        my %bindings = %$bindings;
+        my %bindings = %{$bindings};
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -638,6 +688,11 @@ package Buyo {
     }
 
     my sub register_static_route :ReturnType(Str) ($verb, $bindings, $path) {
+        my $caller = caller;
+        type_check($caller, $verb, 'Str');
+        type_check($caller, $bindings, 'HashRef');
+        type_check($caller, $path, 'Str');
+
         # un-reference to make easier to work with
         my %bindings = %$bindings;
 
@@ -702,6 +757,11 @@ package Buyo {
     }
 
     my sub register_actor_route :ReturnType(Str) ($verb, $bindings, $path) {
+        my $caller = caller;
+        type_check($caller, $verb, 'Str');
+        type_check($caller, $bindings, 'HashRef');
+        type_check($caller, $path, 'Str');
+
         # un-reference to make easier to work with
         my %bindings = %$bindings;
 
@@ -755,6 +815,10 @@ package Buyo {
     }
 
     my sub register_get_routes :ReturnType(Bool) ($bindings, @paths) {
+        my $caller = caller;
+        type_check($caller, $bindings, 'HashRef');
+        type_check($caller, \@paths, 'ArrayRef');
+
         # un-reference to make easier to work with
         my %bindings = %$bindings;
 
@@ -785,6 +849,10 @@ package Buyo {
     }
 
     my sub register_post_routes :ReturnType(Bool) ($bindings, @paths) {
+        my $caller = caller;
+        type_check($caller, $bindings, 'HashRef');
+        type_check($caller, \@paths, 'ArrayRef');
+
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
 
@@ -814,6 +882,9 @@ package Buyo {
     }
 
     our sub main :ReturnType(Void) (@args) {
+        my $caller = caller;
+        type_check($caller, \@args, 'ArrayRef');
+
         my $sub = (caller(0))[3];
 
         set traces  => 1;

--- a/lib/Buyo/Utils.pm
+++ b/lib/Buyo/Utils.pm
@@ -35,6 +35,7 @@ package Buyo::Utils {
     use Types::Standard -all;
 
     use Buyo::Constants;
+    use Sys::Error;
 
     my $VERSION = $Buyo::Constants::VERSION;
 
@@ -45,6 +46,7 @@ package Buyo::Utils {
         # set the version for version checking
         @EXPORT      = qw(
             err_log
+            type_check
         );
         @EXPORT_OK   = qw();
     }
@@ -53,6 +55,25 @@ package Buyo::Utils {
 
     our sub err_log :ReturnType(Void) (@msg) {
         return print {*STDERR} "@msg\n";
+    }
+
+    our sub type_check :ReturnType(Bool) ($caller, $value, $type) {
+        my $e = Sys::Error->new();
+        eval {
+            if (! is_${type}($value)) {
+                my $err_struct = {
+                    'error' => 'Invalid type',
+                    'code'  => 22,
+                    'type'  => $e->err_string(22),
+                    'info'  => "\$value did not match type constraint $type",
+                    'trace' => get_trace(undef, @{$caller})
+                };
+                $e->err_msg($err_struct, @{$caller}[0]);
+                exit 22;
+            } else {
+                return true;
+            }
+        }
     }
 
     sub new :ReturnType(Object) ($class, $debug = false) {

--- a/views/layouts/_index_body.tt
+++ b/views/layouts/_index_body.tt
@@ -25,7 +25,7 @@
         <br />
         <div class="container">
             <div class="padded-row">
-                [% FOREACH article IN articles.sort('id') %]
+                [% FOREACH article IN articles.sort(id) %]
                 <div class="col item bttm-pad">
                     [% IF article.id > 9 %]
                     <a href="[% webroot %]/news/[% article.id %]" class="news">

--- a/views/layouts/_panels_body.tt
+++ b/views/layouts/_panels_body.tt
@@ -18,7 +18,7 @@
         <p>
             Details on how to register a panel will be posted soon!
         </p>
-<!--        <p>
+        <p>
             To register to host a panel, fill out the form below. Panel submissions end
             on May 17th at 11:59pm. You will find out about the status of your panel by
             May 25th.
@@ -48,6 +48,8 @@
                 emergency comes up at event, please notify Con Ops. No-shows will not
                 be eligible for badge reimbursement or for running panels at JAFAX in
                 future years</li>
+            <li>Panelists agree to follow any and all safety and pandemic protocols
+                that are implemented by JAFAX or DeVos Place Convention Center.</li>
         </ul>
         <h3>Reimbursement Policy</h3>
         <ul>
@@ -70,11 +72,7 @@
                 </ul>
             </li>
         </ul>
-        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScIik0ZXxlwkLGbQsqxKTtGAkGhCy8lCJB9B_magnXhsfdrjw/viewform?embedded=true" 
-          width="100%" height="4000px" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe> -->
-        <p>
-            When we get closer to JAFAX 2022, we'll post the schedule for the
-            panels that have been scheduled and approved.
-        </p>
+        <iframe src="https://docs.google.com/forms/d/1EWkbqsFckO57za6aF0bK2qgpx4KaScUx6kFkgv2Xblk/viewform?embedded=true"
+          width="100%" height="3500px" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
     </div>
 </div>


### PR DESCRIPTION
This PR opens panel registration, announces it on the front page, fixes a bug when sorting items on the front page, and enforces type checking for return values and argument variables.

To check argument variables, use the `type_check()` function exported from the Buyo::Utils module. This likely will move to a new module in the future for inclusion in CPAN

Signed-off-by: Gary Greene <greeneg@tolharadys.net>