### PR TITLE
Rework type system handlers (that actually work)

### DIFF
--- a/lib/Buyo.pm
+++ b/lib/Buyo.pm
@@ -46,8 +46,9 @@ package Buyo {
     use lib "$FindBin::Bin/../lib";
 
     use Buyo::Constants;
-    use Buyo::Utils qw(err_log type_check);
+    use Buyo::Utils qw(err_log);
 
+    use Args::TypeCheck qw(type_check);
     use File::IO;
 
     my $VERSION = $Buyo::Constants::VERSION;
@@ -59,9 +60,8 @@ package Buyo {
     my $fio = undef;
 
     my sub error_msg :ReturnType(Void) ($error_struct, $class) {
-        my $caller = caller;
-        type_check($caller, $error_struct, 'Hash');
-        type_check($caller, $class, 'Str');
+        type_check($error_struct, HashRef);
+        type_check($class, Str);
 
         say STDERR "Error struct dump: ". Dumper($error_struct);
 
@@ -79,8 +79,7 @@ package Buyo {
     }
 
     my sub load_config :ReturnType(Hash) ($appdir) {
-        my $caller = caller;
-        type_check($caller, $appdir, 'Str');
+        type_check($appdir, Str);
 
         my $sub = (caller(0))[3];
 
@@ -139,14 +138,11 @@ package Buyo {
         $configuration{'site_key'}        = $cfg->val('reCAPTCHA', 'site_key');
         $configuration{'service_key'}     = $cfg->val('reCAPTCHA', 'service_key');
 
-        err_log("== DEBUGGING ==: Config DUMP: ". Dumper(%configuration));
-
         return %configuration;
     }
 
     my sub get_json :ReturnType(Str) ($json_file) {
-        my $caller = caller;
-        type_check($caller, $json_file, 'Str');
+        type_check($json_file, Str);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -178,9 +174,8 @@ package Buyo {
     }
 
     my sub get_article_from_json :ReturnType(list => Str) ($article, $type) {
-        my $caller = caller;
-        type_check($caller, $article, 'Str');
-        type_check($caller, $type, 'Str');
+        type_check($article, Str);
+        type_check($type, Str);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -229,9 +224,8 @@ package Buyo {
     }
 
     my sub get_file_list :ReturnType(list => Str) ($directory, $extension) {
-        my $caller = caller;
-        type_check($caller, $directory, 'Str');
-        type_check($caller, $extension, 'Str');
+        type_check($directory, Str);
+        type_check($extension, Str);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -250,8 +244,7 @@ package Buyo {
     }
 
     my sub build_menus_struct :ReturnType(Void) ($json_path) {
-        my $caller = caller;
-        type_check($caller, $json_path, 'Str');
+        type_check($json_path, Str);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -280,10 +273,7 @@ package Buyo {
         return $struct;
     }
 
-    my sub build_article_struct_list :ReturnType(ArrayRef[Hash]) () {
-        my $sub = (caller(0))[3];
-        err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
-
+    my sub build_article_struct_list :ReturnType(ArrayRef) () {
         my $appdir = $config->{'appdir'};
         my @files = sort { $b cmp $a } get_file_list("${appdir}content", 'json');
 
@@ -310,8 +300,7 @@ package Buyo {
     }
 
     my sub get_department_contacts :ReturnType(Hash) ($appdir) {
-        my $caller = caller;
-        type_check($caller, $appdir, 'Str');
+        type_check($appdir, Str);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -339,9 +328,8 @@ package Buyo {
     }
 
     my sub get_department_email_from_id :ReturnType(Str) ($appdir, $value) {
-        my $caller = caller;
-        type_check($caller, $appdir, 'Str');
-        type_check($caller, $value, 'Str');
+        type_check($appdir, Str);
+        type_check($value, Str);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -364,8 +352,7 @@ package Buyo {
     }
 
     my sub validate_recaptcha :ReturnType(Bool) ($response_data) {
-        my $caller = caller;
-        type_check($caller, $response_data, 'Str');
+        type_check($response_data, Str);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -403,8 +390,7 @@ package Buyo {
     }
 
     my sub send_email :ReturnType(Void) ($post_values) {
-        my $caller = caller;
-        type_check($caller, $post_values, 'HashRef');
+        type_check($post_values, HashRef);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -434,8 +420,7 @@ package Buyo {
     }
 
     my sub get_last_three_article_structs :ReturnType(ArrayRef[Hash]) ($articles) {
-        my $caller = caller;
-        type_check($caller, $articles, 'ArrayRef');
+        type_check($articles, ArrayRef);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -465,9 +450,8 @@ package Buyo {
     }
 
     my sub validate_page_launch_date :ReturnType(Bool) ($launch_date, $curr_date) {
-        my $caller = caller;
-        type_check($caller, $launch_date, 'Int');
-        type_check($caller, $curr_date, 'Int');
+        type_check($launch_date, Int);
+        type_check($curr_date, Int);
 
         my $do_launch = false;
         if ($curr_date >= $launch_date) {
@@ -478,9 +462,8 @@ package Buyo {
     }
 
     my sub expire_page :ReturnType(Bool) ($expiry_date, $curr_date) {
-        my $caller = caller;
-        type_check($caller, $expiry_date, 'Int');
-        type_check($caller, $curr_date, 'Int');
+        type_check($expiry_date, Int);
+        type_check($curr_date, Int);
 
         my $expire = false;
         if ($expiry_date != -1) {
@@ -493,10 +476,9 @@ package Buyo {
     }
 
     my sub register_dynamic_route :ReturnType(Str) ($verb, $bindings, $path) {
-        my $caller = caller;
-        type_check($caller, $verb, 'Str');
-        type_check($caller, $bindings, 'HashRef');
-        type_check($caller, $path, 'Str');
+        type_check($verb, Str);
+        type_check($bindings, HashRef);
+        type_check($path, Str);
 
         # un-reference to make easier to work with
         my %bindings = %{$bindings};
@@ -688,10 +670,9 @@ package Buyo {
     }
 
     my sub register_static_route :ReturnType(Str) ($verb, $bindings, $path) {
-        my $caller = caller;
-        type_check($caller, $verb, 'Str');
-        type_check($caller, $bindings, 'HashRef');
-        type_check($caller, $path, 'Str');
+        type_check($verb, Str);
+        type_check($bindings, HashRef);
+        type_check($path, Str);
 
         # un-reference to make easier to work with
         my %bindings = %$bindings;
@@ -757,10 +738,9 @@ package Buyo {
     }
 
     my sub register_actor_route :ReturnType(Str) ($verb, $bindings, $path) {
-        my $caller = caller;
-        type_check($caller, $verb, 'Str');
-        type_check($caller, $bindings, 'HashRef');
-        type_check($caller, $path, 'Str');
+        type_check($verb, Str);
+        type_check($bindings, HashRef);
+        type_check($path, Str);
 
         # un-reference to make easier to work with
         my %bindings = %$bindings;
@@ -815,9 +795,8 @@ package Buyo {
     }
 
     my sub register_get_routes :ReturnType(Bool) ($bindings, @paths) {
-        my $caller = caller;
-        type_check($caller, $bindings, 'HashRef');
-        type_check($caller, \@paths, 'ArrayRef');
+        type_check($bindings, HashRef);
+        type_check(\@paths, ArrayRef[Str]);
 
         # un-reference to make easier to work with
         my %bindings = %$bindings;
@@ -849,9 +828,8 @@ package Buyo {
     }
 
     my sub register_post_routes :ReturnType(Bool) ($bindings, @paths) {
-        my $caller = caller;
-        type_check($caller, $bindings, 'HashRef');
-        type_check($caller, \@paths, 'ArrayRef');
+        type_check($bindings, HashRef);
+        type_check(\@paths, ArrayRef[Str]);
 
         my $sub = (caller(0))[3];
         err_log("== DEBUGGING ==: Sub: $sub") if $config->{'debug'};
@@ -882,8 +860,7 @@ package Buyo {
     }
 
     our sub main :ReturnType(Void) (@args) {
-        my $caller = caller;
-        type_check($caller, \@args, 'ArrayRef');
+        type_check(\@args, ArrayRef[Str]);
 
         my $sub = (caller(0))[3];
 

--- a/lib/Buyo/MkRole.pm
+++ b/lib/Buyo/MkRole.pm
@@ -34,7 +34,7 @@ package Buyo::MkRole {
 
     my $VERSION = $Buyo::Constants::VERSION;
 
-    sub new ($class, $flags) {
+    our sub new ($class, $flags) {
         my $self = {};
 
         $debug  = $flags->{'debug'};

--- a/lib/File/IO.pm
+++ b/lib/File/IO.pm
@@ -28,7 +28,7 @@ package File::IO {
 
     $Throw::level = 1;
 
-    sub new :ReturnType(Object) ($class, $flags = undef) {
+    our sub new :ReturnType(Object) ($class, $flags = undef) {
         my $self = {};
 
         $error = Sys::Error->new();

--- a/lib/Sys/Error.pm
+++ b/lib/Sys/Error.pm
@@ -19,7 +19,7 @@ package Sys::Error {
 
     our $VERSION = "0.0.2";
 
-    sub new :ReturnType(Object) ($class) {
+    our sub new :ReturnType(Object) ($class) {
         my $self = {};
 
         bless($self, $class);
@@ -37,22 +37,24 @@ package Sys::Error {
         exit $err_struct->{code};
     }
 
-    our sub get_trace :ReturnType(Str) ($self, @caller) {
+    our sub get_trace :ReturnType(Str) ($self) {
         my %struct = (
-            'package'    => $caller[0],
-            'filename'   => $caller[1],
-            'line'       => $caller[2],
-            'subroutine' => $caller[3],
-            'hasargs'    => $caller[4],
-            'wantarray'  => $caller[5]
+            'package'    => (caller(2))[0],
+            'filename'   => (caller(2))[1],
+            'line'       => (caller(2))[2],
+            'subroutine' => (caller(2))[3],
+            'hasargs'    => (caller(2))[4],
+            'wantarray'  => (caller(2))[5]
         );
-        if (defined $caller[6]) {
-            $struct{'evaltext'} = $caller[6];
+        my $eval_text = (caller(2))[6];
+        if (defined $eval_text) {
+            $struct{'evaltext'} = (caller(2))[6];
         } else {
             $struct{'evaltext'} = "";
         }
-        if (defined $caller[7]) {
-            $struct{'is_require'} = $caller[7];
+        my $is_require = (caller(2))[7];
+        if (defined $is_require) {
+            $struct{'is_require'} = (caller(2))[7];
         } else {
             $struct{'is_require'} = 0;
         }
@@ -66,7 +68,7 @@ package Sys::Error {
         return $trace;
     }
 
-    our sub error_string :ReturnType(Hash) ($self, $error_code) {
+    our sub error_string :ReturnType(HashRef) ($self, $error_code) {
         my $symbol     = undef;
         my $err_string = undef;
         given ($error_code) {


### PR DESCRIPTION
This PR re-works the type handler for validating the data types coming in to functions, moving it's code to the `Args::TypeCheck` package, and dropping the requirement of passing the caller information by changing the `get_trace` function and using the `Type::Utils` package directly to validate a given value's datatype

Signed-off-by: Gary Greene <greeneg@tolharadys.net>