### PR TITLE
Code change to work around Chrome bug

### DIFF
--- a/lib/Buyo/Constants.pm
+++ b/lib/Buyo/Constants.pm
@@ -25,7 +25,7 @@ package Buyo::Constants {
     use boolean qw(:all);
     use base qw(Exporter);
 
-    our $VERSION = "1.2.54";
+    our $VERSION = "1.2.55";
 
     BEGIN {
         use Exporter   ();


### PR DESCRIPTION
If an image has the same name, but different content, Chrome's cache handler ignores the file content change for images.

To work around this, get the file's mtime and append that as a query to the image, which is harmless and ignored by the browser, to force it to note the change of the file, and yet, also ensure that caching for the new image works as expected until the next change of the file.

Signed-off-by: Gary Greene <greeneg@tolharadys.net>